### PR TITLE
Add contact form docs, license and footer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2024 McVogel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software. In addition, visible credit to
+the "McVogel-Portfolio-Template" repository must be present on any website that
+uses the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -44,10 +44,29 @@ export const lightThemeColors = {
 
 Users can switch between a light and dark theme and choose a font in the settings dialog. Available fonts are defined in `src/store/globalSettings.ts`.
 
+## Contact Form
+
+The form shown on the contact page is implemented in `src/components/ContactForm.vue`.
+It uses [vue-recaptcha-v3](https://github.com/dongido/vue-recaptcha-v3) to protect
+against spam. To enable it you must provide a Google reCAPTCHA V3 site key via
+the `VITE_RECAPTCHA_SITE_KEY` environment variable. Create a `.env` file in the
+project root and add your key:
+
+```bash
+VITE_RECAPTCHA_SITE_KEY=your_site_key_here
+```
+
+The component submits the form data to `/api/contact`. You need to implement
+this endpoint yourself to verify the reCAPTCHA token and send the email. Any
+service can be used (for example a small Node backend using Mailjet).
+
 ## Adding/Editing Pages
 
 Pages are placed under `src/pages` and automatically become routes. Components under `src/components` are auto imported so you can simply create a new file and use it in your templates.
 
 ## License
 
-This template is provided without any warranty. Feel free to adapt it for your own portfolio.
+This project is released under the terms of the repository specific license
+found in [`LICENSE`](LICENSE). You may use and modify the template freely, but
+a visible credit linking to this repository must remain on any website built
+with it.

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,12 +8,14 @@
         </transition>
       </router-view>
     </v-main>
+    <AppFooter />
   </v-app>
 </template>
 
 <script lang="ts" setup>
 import { computed, provide } from 'vue'
 import Navigation from '@/components/Navigation.vue'
+import AppFooter from '@/components/AppFooter.vue'
 import { useGlobalSettingsStore } from '@/store/globalSettings'
 
 const store = useGlobalSettingsStore()

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -1,0 +1,26 @@
+<template>
+  <v-footer class="app-footer" app>
+    <v-container class="text-center">
+      <span>
+        Template by
+        <a href="https://github.com/McVogel/McVogel-Portfolio-Template" target="_blank" rel="noopener">McVogel-Portfolio-Template</a>
+      </span>
+    </v-container>
+  </v-footer>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style scoped lang="scss">
+.app-footer {
+  background-color: var(--container-color);
+  color: var(--nav-text-color, #BDBDBD);
+  padding: 16px 0;
+  font-size: 0.875rem;
+}
+.app-footer a {
+  color: rgb(var(--v-theme-primary));
+  text-decoration: none;
+}
+</style>


### PR DESCRIPTION
## Summary
- document how to enable the contact form with reCAPTCHA and a custom backend
- add custom license requiring visible credit
- add footer component referencing the repository

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-vue')*
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d7ff7df0832c92e0acf16d08d280